### PR TITLE
Service endpoint to suggest a match draw.

### DIFF
--- a/xGame/Java/xgame/src/main/java/com/xgame/common/enums/MatchOutcome.java
+++ b/xGame/Java/xgame/src/main/java/com/xgame/common/enums/MatchOutcome.java
@@ -1,0 +1,7 @@
+package com.xgame.common.enums;
+
+public enum MatchOutcome {
+	VICTORY,
+	DRAW,
+	FORFEIT
+}

--- a/xGame/Java/xgame/src/main/java/com/xgame/data/entities/ChessMatch.java
+++ b/xGame/Java/xgame/src/main/java/com/xgame/data/entities/ChessMatch.java
@@ -16,6 +16,7 @@ import javax.persistence.ManyToOne;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import com.xgame.common.enums.MatchOutcome;
 import com.xgame.common.enums.MatchStatus;
 
 @Entity
@@ -28,6 +29,8 @@ public class ChessMatch {
 	@Lob
 	@Column(nullable=false)
 	private String chessBoard;
+	private Boolean IsDrawSuggestedByWhite;
+	private Boolean IsDrawSuggestedByBlack;
 	@CreationTimestamp
 	private Timestamp creationTimestamp;
 	private Timestamp startTimestamp;
@@ -46,12 +49,8 @@ public class ChessMatch {
 	private User winningPlayer;
 	@Enumerated(EnumType.STRING)
 	private MatchStatus matchStatus;
-	
-	/*
-	@OneToOne
-	@JoinColumn(name = "matchStatusId", referencedColumnName = "id", nullable=false)
-	private MatchStatus matchStatus;
-	*/
+	@Enumerated(EnumType.STRING)
+	private MatchOutcome matchOutcome;
 	
 	//constructors
 	protected ChessMatch() {}
@@ -75,6 +74,18 @@ public class ChessMatch {
 	}
 	public void setChessBoard(String chessBoard) {
 		this.chessBoard = chessBoard;
+	}
+	public Boolean getIsDrawSuggestedByWhite() {
+		return IsDrawSuggestedByWhite;
+	}
+	public void setIsDrawSuggestedByWhite(Boolean isDrawSuggestedByWhite) {
+		IsDrawSuggestedByWhite = isDrawSuggestedByWhite;
+	}
+	public Boolean getIsDrawSuggestedByBlack() {
+		return IsDrawSuggestedByBlack;
+	}
+	public void setIsDrawSuggestedByBlack(Boolean isDrawSuggestedByBlack) {
+		IsDrawSuggestedByBlack = isDrawSuggestedByBlack;
 	}
 	public Timestamp getCreationTimestamp() {
 		return creationTimestamp;
@@ -111,5 +122,11 @@ public class ChessMatch {
 	}
 	public void setMatchStatus(MatchStatus matchStatus) {
 		this.matchStatus = matchStatus;
+	}
+	public MatchOutcome getMatchOutcome() {
+		return matchOutcome;
+	}
+	public void setMatchOutcome(MatchOutcome matchOutcome) {
+		this.matchOutcome = matchOutcome;
 	}
 }

--- a/xGame/Java/xgame/src/main/java/com/xgame/restservice/controller/ChessMatchController.java
+++ b/xGame/Java/xgame/src/main/java/com/xgame/restservice/controller/ChessMatchController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.xgame.common.enums.MatchOutcome;
 import com.xgame.common.viewmodels.MatchViewModel;
 import com.xgame.service.interfaces.IChessMatchService;
 
@@ -28,6 +29,11 @@ public class ChessMatchController {
 	public MatchViewModel acceptInvite(@RequestParam(value = "matchId") int matchId) {
 		var match = matchService.acceptInvite(matchId);
 		return match;
+	}
+	
+	@PatchMapping("/match/draw")
+	public MatchOutcome draw(@RequestParam(value = "matchId") int matchId, @RequestParam(value = "playerId") int playerId) {
+		return matchService.suggestDraw(matchId, playerId);
 	}
 	
 	@GetMapping("/match")

--- a/xGame/Java/xgame/src/main/java/com/xgame/service/interfaces/IChessMatchService.java
+++ b/xGame/Java/xgame/src/main/java/com/xgame/service/interfaces/IChessMatchService.java
@@ -1,5 +1,6 @@
 package com.xgame.service.interfaces;
 
+import com.xgame.common.enums.MatchOutcome;
 import com.xgame.common.viewmodels.MatchViewModel;
 
 public interface IChessMatchService {
@@ -8,4 +9,5 @@ public interface IChessMatchService {
 	MatchViewModel getMatch(int id);
 	MatchViewModel updateMatch(MatchViewModel matchState);
 	MatchViewModel EndMatch(MatchViewModel matchState, int winnerId);
+	MatchOutcome suggestDraw(int matchId, int playerId);
 }


### PR DESCRIPTION
- API endpoint to suggest match draw
- service suggest match draw. Creates a suggestion for that player on the match entity. If both players suggest a draw, this service will end the match with a match outcome of DRAW. Sends messages to players on draw suggestion and acceptance. Returns match outcome of NULL or DRAW.
- unit test